### PR TITLE
[Modding Docs] Add warning about certain API references being unusable.

### DIFF
--- a/docs/modding/type-reference.mdx
+++ b/docs/modding/type-reference.mdx
@@ -105,26 +105,26 @@ interface Train {
 ```ts
 type Coordinate = [number, number]; // [longitude, latitude]
 type BoundingBox = [number, number, number, number]; // [minLng, minLat, maxLng, maxLat]
-type GameSpeed = "slow" | "normal" | "fast" | "ultrafast";
-type BuildType = "blueprint" | "built";
+type GameSpeed = 'slow' | 'normal' | 'fast' | 'ultrafast';
+type BuildType = 'blueprint' | 'built';
 ```
 
 ### UI types
 
 ```ts
 type UIPlacement =
-  | "settings-menu"
-  | "escape-menu"
-  | "escape-menu-buttons"
-  | "main-menu"
-  | "bottom-bar"
-  | "top-bar"
-  | "debug-panel"
-  | "menu-items"
-  | "pause-menu"
-  | "debug";
+  | 'settings-menu'
+  | 'escape-menu'
+  | 'escape-menu-buttons'
+  | 'main-menu'
+  | 'bottom-bar'
+  | 'top-bar'
+  | 'debug-panel'
+  | 'menu-items'
+  | 'pause-menu'
+  | 'debug';
 
-type NotificationType = "success" | "error" | "info" | "warning";
+type NotificationType = 'success' | 'error' | 'info' | 'warning';
 ```
 
 ## Extending types
@@ -133,7 +133,7 @@ If you need to extend the API types (e.g., adding fields you've discovered at ru
 
 ```ts
 // src/types/my-extensions.d.ts
-declare module "./game-state" {
+declare module './game-state' {
   interface Station {
     myCustomField?: string;
   }


### PR DESCRIPTION
Add warning about certain API types not being available and cross them out as unusable.

We will need to add `storage.d.ts` to the template repo: https://www.subwaybuilder.com/docs/v1.0.0/api-reference/storage
<img width="1060" height="630" alt="image" src="https://github.com/user-attachments/assets/0f5344c8-b9a4-4603-8c06-284f4811cd10" />

<img width="1067" height="189" alt="image" src="https://github.com/user-attachments/assets/ea719b83-f58f-4145-b965-143d1a246b80" />
